### PR TITLE
feat: allow wildcard github refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "oidc_role" {
 
   github_repository = "stroeer/example"
   role_name         = "github-ci-role"
-  github_refs       = ["main", "develop"]
+  github_refs       = ["main", "develop", "release/*"]
 
   ecr_repositories = [
     "example-repository"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,7 +9,7 @@ module "oidc_role" {
 
   github_repository = "stroeer/example"
   role_name         = "github-ci-role"
-  github_refs       = ["main", "develop"]
+  github_refs       = ["main", "develop", "release/*"]
 
   ecr_repositories = [
     "example-repository"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "github_actions_assume" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
 
     condition {
-      test     = "StringEquals"
+      test     = "StringLike"
       values   = local.allowed_subs
       variable = "token.actions.githubusercontent.com:sub"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "github_repository" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 variable "github_refs" {
-  description = "Name of the refs (e.g. branches) on which the action will run."
+  description = "Name of the refs (e.g. branches) on which the action will run. Can contain '*' wildcards."
   type        = list(string)
   default     = ["main"]
   nullable    = false


### PR DESCRIPTION
Allows to use wildcards in github refs that will allow the role to be assumed, e.g. like `release/*.*.*`.