### PR TITLE
feat(BUZZ-6726): also allow assuming from GitHub environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ module "oidc_role" {
   source     = "registry.terraform.io/stroeer/github-oidc-role/aws"
   depends_on = [aws_iam_openid_connect_provider.github]
 
-  github_repository = "stroeer/example"
-  role_name         = "github-ci-role"
-  github_refs       = ["main", "develop", "release/*"]
+  github_repository   = "stroeer/example"
+  role_name           = "github-ci-role"
+  github_refs         = ["main", "develop", "release/*"]
+  github_environments = ["staging"]
 
   ecr_repositories = [
     "example-repository"
@@ -150,6 +151,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ecr_repositories"></a> [ecr\_repositories](#input\_ecr\_repositories) | ECR repository names that the role can push to. If not set, no ECR access will be granted. | `list(string)` | `[]` | no |
+| <a name="input_github_environments"></a> [github\_environments](#input\_github\_environments) | Name of the environments on which the action can run. Can contain '*' wildcards. | `list(string)` | `[]` | no |
 | <a name="input_github_refs"></a> [github\_refs](#input\_github\_refs) | Name of the refs (e.g. branches) on which the action will run. Can contain '*' wildcards. | `list(string)` | <pre>[<br/>  "main"<br/>]</pre> | no |
 | <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Name of the GitHub repository that will run the action, including repository owner (e.g. moritzzimmer/terraform-aws-lambda) | `string` | n/a | yes |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the IAM role to create. If not set github-actions-$github\_repository-$region will be used | `string` | `""` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,9 +7,10 @@ module "oidc_role" {
   source     = "../../"
   depends_on = [aws_iam_openid_connect_provider.github]
 
-  github_repository = "stroeer/example"
-  role_name         = "github-ci-role"
-  github_refs       = ["main", "develop", "release/*"]
+  github_repository   = "stroeer/example"
+  role_name           = "github-ci-role"
+  github_refs         = ["main", "develop", "release/*"]
+  github_environments = ["staging"]
 
   ecr_repositories = [
     "example-repository"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
-  role_name           = var.role_name != "" ? var.role_name : "github-actions-${split("/", var.github_repository)[1]}-${data.aws_region.current.region}"
-  allowed_subs        = [for ref in var.github_refs : "repo:${var.github_repository}:ref:refs/heads/${ref}"]
+  role_name = var.role_name != "" ? var.role_name : "github-actions-${split("/", var.github_repository)[1]}-${data.aws_region.current.region}"
+  allowed_subs = concat(
+    [for ref in var.github_refs : "repo:${var.github_repository}:ref:refs/heads/${ref}"],
+    [for env in var.github_environments : "repo:${var.github_repository}:environment:${env}"]
+  )
   s3_bucket_name_arns = [for prefix in var.s3_prefixes : "arn:aws:s3:::${split("/", prefix)[0]}"]
   s3_prefix_arns      = [for prefix in var.s3_prefixes : "arn:aws:s3:::${prefix}/*"]
   ecr_repository_arns = [for repo in var.ecr_repositories : "arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/${repo}"]

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,13 @@ variable "github_refs" {
   nullable    = false
 }
 
+variable "github_environments" {
+  description = "Name of the environments on which the action can run. Can contain '*' wildcards."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "role_name" {
   description = "Name of the IAM role to create. If not set github-actions-$github_repository-$region will be used"
   type        = string


### PR DESCRIPTION
When a GitHub workflow runs in an environment the `sub` will not be the branch but the environment in the format

```
repo:$name:environment:$env
```

The new variable allows to also specifify environemnts that can assume the role.